### PR TITLE
updated RTD requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+urllib3<2.0
 sphinx-markdown-tables==0.0.16
 sphinx-rtd-theme==1.0.0


### PR DESCRIPTION
RTD build breaks with latest upgrade to urllib ([https://github.com/urllib3/urllib3/issues/2168](https://github.com/urllib3/urllib3/issues/2168))