### PR TITLE
Matlab explorer

### DIFF
--- a/docs/source/software/systemwide/matlab.md
+++ b/docs/source/software/systemwide/matlab.md
@@ -19,19 +19,19 @@ Use the following procedure if you need to install a MATLAB toolbox:
 1. Create a directory in your /home directory. We recommend creating a directory called `matlab` by typing:
 
    :::
-   mkdir /home/<username>/matlab  #where <username> is your username
+   mkdir /home/a.noether/matlab  # please substitute your username for the example `a.noether`
    :::
 
 1. Go to the directory you just created by typing:
 
    :::
-   cd /home/<username>/matlab
+   cd /home/a.noether/matlab
    :::
 
 1. Unzip the toolbox file by typing:
 
    :::
-   unzip <toolboxname>
+   unzip toolboxname.zip
    :::
 
 1. Load MATLAB by typing:
@@ -49,7 +49,7 @@ Use the following procedure if you need to install a MATLAB toolbox:
 1. Add the toolbox to your PATH by typing:
 
    :::
-   addpath('/home/<username>/matlab/<toolbox>') #where <toolbox> is the name of the toolbox you just unzipped
+   addpath('/home/a.noether/matlab/toolboxname') # where toolboxname is the name of the toolbox you just unzipped
    :::
 
 1. If this is a toolbox you want to use more than once, you should save it to your path by typing:

--- a/docs/source/software/systemwide/matlab.md
+++ b/docs/source/software/systemwide/matlab.md
@@ -72,11 +72,11 @@ The cluster has MATLAB Parallel Server installed and this section details an exa
 
 1. Click **Interactive Apps**, and select **MATLAB**.
 
-1. Select **MATLAB version R2023a** or newer, and set the time for the length of your job, the number of cpus to be 8, and the memory to at least 16 GB. Click **Launch**.
+1. Select **MATLAB version R2024b** or newer, and set the time for the length of your job, the number of cpus to be 8, and the memory to at least 16 GB. Click **Launch**.
 
 1. If necessary, adjust the **Compression** and **Image Quality**, and then click **Launch MATLAB**.
 
-1. Once MATLAB is open, click on the Home tab, click Parallel > Discover Clusters... to discover the profile. This will open a window where you should select 'on your network' and click next and then select 'Discovery' and click finished. Note, this is valid for R2023a and newer. Create a cluster profile to run parallel jobs by running `configCluster` in the Command Window. Note: `configCluster` should only be called once on the HPC.
+1. Once MATLAB is open, click on the Home tab, click Parallel > Discover Clusters... to discover the profile. This will open a window where you should select 'on your network' and click next and then select 'Discovery' and click finished. Note, this is valid for R2024b and newer. Create a cluster profile to run parallel jobs by running `configCluster` in the Command Window. Note: `configCluster` should only be called once on the HPC.
 
 Now MATLAB is configured to have jobs submitted to the HPC cluster and not run in the current session.
 :::::

--- a/docs/source/software/systemwide/matlab.md
+++ b/docs/source/software/systemwide/matlab.md
@@ -76,7 +76,7 @@ The cluster has MATLAB Parallel Server installed and this section details an exa
 
 1. If necessary, adjust the **Compression** and **Image Quality**, and then click **Launch MATLAB**.
 
-1. Once MATLAB is open, click on the Home tab, click Parallel > Discover Clusters... to discover the profile. This will open a window where you should select 'on your network' and click next and then select 'Discovery' and click finished. Note, this is valid for R2024b and newer. Create a cluster profile to run parallel jobs by running `configCluster` in the Command Window. Note: `configCluster` should only be called once on the HPC.
+1. Once MATLAB is open, click on the Home tab, click Parallel > Discover Clusters... to discover the profile. This will open a window where you should select 'on your network' and click next and then select 'Explorer' and click finished. Note, this is valid for R2024b and newer. Create a cluster profile to run parallel jobs by running `configCluster` in the Command Window. Note: `configCluster` should only be called once on the HPC.
 
 Now MATLAB is configured to have jobs submitted to the HPC cluster and not run in the current session.
 :::::

--- a/docs/source/software/systemwide/matlab.md
+++ b/docs/source/software/systemwide/matlab.md
@@ -66,7 +66,7 @@ Use the following procedure if you need to install a MATLAB toolbox:
 :::::{tab-item} MATLAB on OOD
 **Configuration of MATLAB client on the HPC**
 
-The cluster has MATLAB Parallel Server installed and this section details an example of how you can set up and use the MATLAB Parallel Computing Toolbox on the HPC. This walkthrough uses MATLAB R2023a launched as an interactive app on the [Open OnDemand](ood.explorer.northeastern.edu) web portal. There are several parts to this walkthrough so we suggest that you read it through completely before starting. The parameters presented represent only one scenario and the results may differ when you run the examples.
+The cluster has MATLAB Parallel Server installed and this section details an example of how you can set up and use the MATLAB Parallel Computing Toolbox on the HPC. This walkthrough uses MATLAB R2024b launched as an interactive app on the [Open OnDemand](https://ood.explorer.northeastern.edu) web portal. There are several parts to this walkthrough so we suggest that you read it through completely before starting. The parameters presented represent only one scenario and the results may differ when you run the examples.
 
 1. Go to <http://ood.explorer.northeastern.edu>. If prompted, sign in with your cluster username and password.
 


### PR DESCRIPTION
Test out parpool and toolbox installation for matlab on explorer. I ran into an error at the command: pool = c.parpool(64);
but everything else seemed to work. was able to submit jobs from matlab to the cluster. 